### PR TITLE
docs: add Felix Schneider to MEMBERS.md

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -12,3 +12,5 @@ Members are listed in alphabetical order, by first name. Members are free to use
 ## Revered (Maintainers)
 
 ## Honoured (Support & Triage)
+
+- Felix Schneider [@trueberryless](https://github.com/trueberryless)


### PR DESCRIPTION
Thanks for giving us the opportunity 🙌 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restored the “Honoured (Support & Triage)” section under “Revered (Maintainers)” in the contributors documentation.
  * Added a new member entry: Felix Schneider (GitHub: @trueberryless) under the “Honoured (Support & Triage)” section, including a profile link.
  * Aligned the contributors list structure to reflect the current sections and membership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->