### PR TITLE
make headings consistent in PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->
 
-#### Description
+## Description
 
 - Closes # <!-- If applicable add an issue number to this PR so it can be closed otherwise feel free to remove this. -->
 - What does this PR change?


### PR DESCRIPTION
<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### Description

* Update the PR template to make `Description` an h2 like the other headings.

Maybe there was a reason for that, but while filling #9 it seemed weird that "Description" was an h4 while the other headings are h2. (you can also see that in this PR)

## Testing

N/A

## Docs

This updates the template, so kinda docs.

<!--
Here’s what will happen next:

One of our maintainers will review your pull request as soon as possible. We strive to provide feedback within a day, but please understand that responses may occasionally take longer depending on the circumstance and our availability. If we request any changes, please feel free to ask for clarification or provide additional context. We appreciate your patience and contribution to the project.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the pull request template to use “## Description” for clearer, more consistent section hierarchy.
  * Corrected the closing of an HTML comment at the end of the template to prevent rendering issues and stray formatting in PR previews.

* **Chores**
  * Performed minor template maintenance to improve readability and contributor experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->