### PR TITLE
Add RATIU5 to member list

### DIFF
--- a/MEMBERS.md
+++ b/MEMBERS.md
@@ -15,3 +15,4 @@ Members are listed in alphabetical order, by first name. Members are free to use
 
 - Armand Philippot [@ArmandPhilippot](https://github.com/ArmandPhilippot)
 - Felix Schneider [@trueberryless](https://github.com/trueberryless)
+- John Memmott [@RATIU5](https://github.com/RATIU5)


### PR DESCRIPTION
Add RATIU5 to member list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Updated the community members listing to include John Memmott (@RATIU5) under the Honoured (Support & Triage) section.
  * Improves visibility and recognition of contributor support roles.
  * No user-facing functionality changes or behavioral impacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->